### PR TITLE
Fix: dead connections used for commands (IMAP)

### DIFF
--- a/src/modules/imap/pool.rs
+++ b/src/modules/imap/pool.rs
@@ -25,7 +25,10 @@ impl bb8::ManageConnection for ImapConnectionManager {
     }
     // call this function before using the connection
     async fn is_valid(&self, conn: &mut Self::Connection) -> RustMailerResult<()> {
-        match tokio::time::timeout(Duration::from_secs(5), conn.noop()).await {
+        if conn.is_bad {
+            return Err(raise_error!(format!("Connection marked broken"), ErrorCode::ImapCommandFailed));
+        }
+        match tokio::time::timeout(Duration::from_secs(5), conn.run_command_and_check_ok("NOOP")).await {
             Ok(Ok(_)) => Ok(()),
             Ok(Err(e)) => {
                 error!("IMAP connection validation failed: {:?}", e);

--- a/src/modules/utils/net.rs
+++ b/src/modules/utils/net.rs
@@ -16,7 +16,7 @@ use tokio_io_timeout::TimeoutStream;
 use tokio_socks::tcp::Socks5Stream;
 use tracing::error;
 
-pub(crate) const TIMEOUT: Duration = Duration::from_secs(60);
+pub(crate) const TIMEOUT: Duration = Duration::from_secs(3600);
 
 pub(crate) async fn establish_tcp_connection_with_timeout(
     address: SocketAddr,


### PR DESCRIPTION
**The problem:**
The IMAP pool uses connections that were already dead.

**The Fix:**
Calling noop by run_command_and_check function instead of noop command. Also it checks first if the connection is already dead. 

....And pump up the connection timeout, so that connections aren't lost in the first place.